### PR TITLE
fix typo kubentes

### DIFF
--- a/deepce.sh
+++ b/deepce.sh
@@ -347,7 +347,7 @@ containerCheck() {
   # Are we inside kubenetes?
   if grep "/kubepod" /proc/1/cgroup -qa; then
     inContainer="1"
-    containerType="kubentes"
+    containerType="kubernetes"
   fi
 
   # Are we inside LXC?


### PR DESCRIPTION
Just noticed that "kubentes" is probably "kubernetes" :] 