### PR TITLE
Add dangerous capabilities & display without capsh

### DIFF
--- a/deepce.sh
+++ b/deepce.sh
@@ -129,7 +129,7 @@ TIP_CVE_2019_5736="Docker versions before 18.09.2 are vulnerable to a container 
 TIP_SYS_MODULE="Giving the container the SYS_MODULE privilege allows for kernel modules to be mounted. Using this, a malicious module can be used to execute code as root on the host."
 
 DANGEROUS_GROUPS="docker\|lxd\|root\|sudo\|wheel"
-DANGEROUS_CAPABILITIES="cap_sys_admin\|cap_sys_ptrace\|cap_sys_module\|dac_read_search\|dac_override"
+DANGEROUS_CAPABILITIES="cap_sys_admin\|cap_sys_ptrace\|cap_sys_module\|dac_read_search\|dac_override\|cap_sys_rawio\|cap_mknod"
 
 CONTAINER_CMDS="docker lxc rkt kubectl podman"
 USEFUL_CMDS="curl wget gcc nc netcat ncat jq nslookup host hostname dig python python2 python3 nmap"

--- a/deepce.sh
+++ b/deepce.sh
@@ -561,7 +561,13 @@ containerCapabilities() {
         printNo
     fi
   else
-    printError "Unknown (capsh not installed)"
+    caps=$(cat /proc/$PPID/status | grep Cap)
+    capEff=$(cat /proc/$PPID/status | grep CapEff | cut -d ':' -f 2 | tr -d '\t')
+    printError "Unknown"
+    printInstallAdvice "libcap2-bin"
+    printStatus "Current PPID capabilities are:"
+    printStatus "$caps"
+    printStatus "> Try to decode them with \"capsh --decode=00000000a80425fb\""
   fi
 }
 


### PR DESCRIPTION
I propose to add these capabilities identification: 

- **cap_sys_rawio** (read https://book.hacktricks.xyz/linux-hardening/privilege-escalation/linux-capabilities#cap_sys_rawio)
- **cap_mknod** (read https://labs.withsecure.com/publications/abusing-the-access-to-mount-namespaces-through-procpidroot)

And, I propose to display the capabilities, even is `capsh` is not installed:
![image](https://user-images.githubusercontent.com/2116674/212962197-b73bfced-2928-4d7e-bc91-86448735fa69.png)
