### PR TITLE
Adding detection for CVE-2025-9074

### DIFF
--- a/deepce.sh
+++ b/deepce.sh
@@ -646,6 +646,50 @@ containerExploits() {
       printNo
     fi
   fi
+
+  # If docker api is exposed check for CVE-2025-9074
+  if [ -x "$(command -v curl)" ] || [ -x "$(command -v wget)" ]; then
+    printQuestion "Docker API exposed ......."
+    api_available="0"
+    
+    if [ -x "$(command -v curl)" ]; then
+      curl -s --connect-timeout 1 http://192.168.65.7:2375/version >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        api_available="1"
+      fi
+    elif [ -x "$(command -v wget)" ]; then
+      wget -O - http://192.168.65.7:2375/version --connect-timeout=1 --tries=1 -q >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        api_available="1"
+      fi
+    fi
+    
+    if [ "$api_available" = "0" ]; then
+      printNo
+      return
+    fi
+    
+    printSuccess "Yes"
+    printQuestion "└── CVE-2025-9074 ......."
+    
+    if [ -x "$(command -v curl)" ]; then
+      curl -s --connect-timeout 1 http://192.168.65.7:2375/containers/json >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        printYesEx
+        printTip "$TIP_CVE_2025_9074"
+      else
+        printNo
+      fi
+    elif [ -x "$(command -v wget)" ]; then
+      wget -O - http://192.168.65.7:2375/containers/json --connect-timeout=1 --tries=1 -q >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        printYesEx
+        printTip "$TIP_CVE_2025_9074"
+      else
+        printNo
+      fi
+    fi
+  fi
 }
 
 enumerateContainers() {

--- a/deepce.sh
+++ b/deepce.sh
@@ -125,6 +125,7 @@ TIP_DOCKER_ROOTLESS="In rootless mode privilege escalation to root will not be p
 TIP_CVE_2019_5021="Alpine linux version 3.3.x-3.5.x accidentally allow users to login as root with a blank password, if we have command execution in the container we can become root using su root"
 TIP_CVE_2019_13139="Docker versions before 18.09.4 are vulnerable to a command execution vulnerability when parsing URLs"
 TIP_CVE_2019_5736="Docker versions before 18.09.2 are vulnerable to a container escape by overwriting the runC binary"
+TIP_CVE_2025_9074="Docker Desktop versions between 4.25 to 4.44.2 on Windows and MacOS are vulnerable to a container escape via a malicious image. See https://github.com/PtechAmanja/CVE-2025-9074-Docker-Desktop-Container-Escape"
 
 TIP_SYS_MODULE="Giving the container the SYS_MODULE privilege allows for kernel modules to be mounted. Using this, a malicious module can be used to execute code as root on the host."
 


### PR DESCRIPTION
This pull request enhances CVE-2025-9074 detection. It draws from the HackTheBox "MonitorsFour" challenge (https://app.hackthebox.com/machines/MonitorsFour?tab=play_machine), which exploits this vulnerability, currently undetected by Deepce, adding targeted coverage for container escape scenarios via unauthenticated Docker API access on port 2375.